### PR TITLE
EditorConfig Settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,79 @@
+root = true
+
+
+## PML Sources
+##############
+[*.pml]
+charset = utf-8
+end_of_line = unset
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+
+## Repository Configurations
+############################
+[.{git*,editorconfig}]
+indent_style = space
+indent_size = unset
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.gitmodules]
+indent_style = tab
+
+[.gitkeep]
+insert_final_newline = false
+
+
+## Shell Scripts
+################
+[*.sh]
+end_of_line = lf
+indent_style = tab
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Batch Scripts
+################
+[*.{bat,cmd}]
+indent_style = tab
+indent_size = unset
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Markdown GFM
+###############
+[*.md]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+## Plain-Text Files
+###################
+[*.txt]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{LICENSE,README}]
+indent_size = unset
+indent_style = space
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto
+
+## Repository Configuration
+###########################
+.editorconfig    text eol=lf
+.travis.yml      text eol=lf
+.gitattributes   text eol=lf
+.gitconfig       text eol=lf
+.gitignore       text eol=lf
+.gitmodules      text eol=lf
+
+## Documentation Files
+######################
+*.md         text
+*.pml        text linguist-language=PML
+*.txt        text
+LICENSE      text
+
+## Scripts
+##########
+*.bat   text eol=crlf
+*.com   text eol=crlf
+*.sh    text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,41 @@
 
 # Directories and files starting with NOGIT_
 **/NOGIT_*
+
+############################
+## COMMON IGNORE PATTERNS ##
+############################
+
+## Apps Local Settings & Temp Files
+###################################
+
+# Chrome's debug logs for local HTML pages:
+debug.log
+
+# Links and URLs:
+*.lnk
+*.url
+
+## Linux
+########
+*~
+.directory
+.fuse_hidden*
+.nfs*
+.Trash-*
+
+## macOS
+########
+*.DS_Store
+._*
+.AppleDouble
+.LSOverride
+Icon
+
+## Windows
+##########
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+.BIN/


### PR DESCRIPTION
Improve repository settings to enforce consistent code styles across
different OSs and editors by adding EditorConfig rules and tweaking
Git configurations:

* New `.editorconfig` and `.gitattributes` configuration files to
  enforce consistent code style rules for:
    * Repository configuration files.
    * Plain-text and LICENSE files.
    * Shell and batch scripts.
    * Markdown document.
    * PML documents.
* Add to `.gitignore` new rules to cover common OSs and application
  temporary files that are likely to occur on end users machines.

These settings will reduce noise in commits and PRs by avoiding
spurious whitespace changes enforced by custom editor settings
(conversion of spaces to tabs, etc.) ending up in new commits and
pull requests, restricting them to actual contents changes.